### PR TITLE
build: 📦 Add missing license

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ name = "windows-artifacts-generator"
 version = "1.0.0"
 edition = "2021"
 description = "Generate malware artifacts for detection tests"
+license = "GPL-3.0-or-later"
 
 [[bin]]
 name = "wag"


### PR DESCRIPTION
It's needed for publishing the crate